### PR TITLE
Pre loaded food names into global state

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -8,18 +8,24 @@ import {
   Link,
 } from '@material-ui/core';
 import Auth from '../interfaces/auth/Auth';
-import { setUserDetailsAction } from '../store/global/actions';
+import { setFoodNamesAction, setUserDetailsAction } from '../store/global/actions';
 import { connect } from 'react-redux';
 import HeaderLink from './HeaderLink';
 import { setUserDetailsWithRole } from '../helpers/userUtils';
-import { MIN_WIDTH } from '../helpers/constants';
+import { EDAMAM_DB, MIN_WIDTH } from '../helpers/constants';
+import { getAllFoodNames } from '../interfaces/api/foods';
 
 const auth = new Auth();
 
-const Header = ({ classes, userDetails, setUserDetails }) => {
-  useEffect(() => {
+const Header = ({ classes, userDetails, setUserDetails, setFoodNames }) => {
+  useEffect(async () => {
     const userInfo = auth.extractUserFromToken();
     setUserDetailsWithRole(setUserDetails, userInfo);
+
+    if (!EDAMAM_DB) {
+      const foodNames = await getAllFoodNames();
+      setFoodNames(foodNames);
+    }
   }, []);
 
   function handleLogin() {
@@ -71,6 +77,7 @@ Header.propTypes = {
   classes: PropTypes.object.isRequired,
   userDetails: PropTypes.object.isRequired,
   setUserDetails: PropTypes.func.isRequired,
+  setFoodNames: PropTypes.func.isRequired,
 };
 
 const styles = {
@@ -98,15 +105,16 @@ const styles = {
   },
 };
 
-const mapStateToProps = (states, ownProps) => {
+const mapStateToProps = states => {
   return {
     userDetails: states.globalState.userDetails,
   };
 };
 
-const mapDispatchToProps = (dispatch, ownProps) => {
+const mapDispatchToProps = dispatch => {
   return {
     setUserDetails: details => dispatch(setUserDetailsAction(details)),
+    setFoodNames: foodNames => dispatch(setFoodNamesAction(foodNames)),
   };
 };
 

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -4,10 +4,9 @@ const ROLES = {
   ADMIN: 5,
   CONTRIBUTOR: 100,
 };
-const INPUT_TRIGGER_TIME = 700;
 const MIN_WIDTH = 960;
 const EDAMAM_DB = false;
-
+const INPUT_TRIGGER_TIME = EDAMAM_DB ? 700 : 300;
 const CATEGORIES = [
   { group: 'A', name: 'Cereals and cereal products', selected: true },
   { group: 'B', name: 'Milk and milk products', selected: true },

--- a/helpers/utils.js
+++ b/helpers/utils.js
@@ -35,11 +35,11 @@ const mapSearchResults = results => {
   return results.map(item => ({
     food_id: item.foodCode,
     food_name: item.foodName,
+    food_group: item.group,
   }));
 };
 
-
-// Function to extract groups and subgroups from a CoFID food record
+// Function to generate applicable groups and subgroups to use for CoFID foods search
 const getFoodGroups = groups => {
   if (!groups) return;
 
@@ -52,4 +52,4 @@ const getFoodGroups = groups => {
   return subgroups;
 };
 
-export { getTime, emptyFood, fullTrim, lowerCaseCompare, mapSearchResults, getFoodGroups};
+export { getTime, emptyFood, fullTrim, lowerCaseCompare, mapSearchResults, getFoodGroups };

--- a/interfaces/api/foods.js
+++ b/interfaces/api/foods.js
@@ -17,4 +17,10 @@ const getFood = (id, context = 'getFoodData') =>
     context
   );
 
-export { getFoods, getFood };
+const getAllFoodNames = (context = 'getAllFoodNames') =>
+  trackPromise(
+    getRequest(`${foodApiEndpoint}/names`),
+    context
+  );
+
+export { getFoods, getFood, getAllFoodNames };

--- a/pages/api/foods/names/index.js
+++ b/pages/api/foods/names/index.js
@@ -1,7 +1,7 @@
-import { getAllFoods } from '../../../../server/foods/foods';
+import { getAllFoodNames } from '../../../../server/foods/foods';
 
 const getCollectionResults = async (req, res) => {
-  const result = await getAllFoods();
+  const result = await getAllFoodNames();
 
   return result ? res.status(200).json(result) : res.status(404);
 };

--- a/server/foods/foods.js
+++ b/server/foods/foods.js
@@ -22,9 +22,9 @@ const getFood = async id => {
   return FoodsConnection.findOne({ foodCode: id });
 };
 
-const getAllFoods = async () => {
+const getAllFoodNames = async () => {
   const FoodsConnection = await getFoodsConnection();
-  return FoodsConnection.find({});
+  return FoodsConnection.find({}, { foodCode: 1, foodName: 1, group: 1, _id: 0 });
 };
 
-export { getFoods, getFood, getAllFoods };
+export { getFoods, getFood, getAllFoodNames };

--- a/store/global/actions.js
+++ b/store/global/actions.js
@@ -2,6 +2,7 @@ export const ActionsTypes = {
   SET_USER_DETAILS: 'SET_USER_DETAILS',
   ADD_USER_POINTS: 'ADD_USER_POINTS',
   SET_CATEGORIES: 'SET_CATEGORIES',
+  SET_FOOD_NAMES: 'SET_FOOD_NAMES',
 };
 
 export const setUserDetailsAction = userDetails => {
@@ -14,4 +15,8 @@ export const addUserPointsAction = points => {
 
 export const setCategoriesAction = categories => {
   return { type: ActionsTypes.SET_CATEGORIES, categories };
+};
+
+export const setFoodNamesAction = foodNames => {
+  return { type: ActionsTypes.SET_FOOD_NAMES, foodNames };
 };

--- a/store/global/reducer.js
+++ b/store/global/reducer.js
@@ -8,7 +8,7 @@ const userWithAddedPoints = (userDetails, points) => {
   }
 };
 
-export const reducer = (state = { userDetails: {}, categories: CATEGORIES }, action) => {
+export const reducer = (state = { userDetails: {}, categories: CATEGORIES, foodNames: [] }, action) => {
   if (action.type === ActionsTypes.SET_USER_DETAILS) {
     return {
       ...state,
@@ -24,6 +24,11 @@ export const reducer = (state = { userDetails: {}, categories: CATEGORIES }, act
       ...state,
       categories: action.categories,
     };
+  } else if (action.type === ActionsTypes.SET_FOOD_NAMES) {
+    return {
+      ...state,
+      foodNames: action.foodNames,
+    }
   } else {
     return state;
   }


### PR DESCRIPTION
Preloading all food names initially so we don't have to make an API request each time we change the search input. This will only work when using CoFID database.
If Edamam is enabled the behaviour will be the previous one where it caches searches but still triggers an API call per search.