### PR TITLE
Analytics fix: Added extra check for production

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -35,7 +35,7 @@ export default class MyDocument extends Document {
         enhanceApp: (App) => (props) => sheets.collect(<App {...props} />),
       });
 
-    const isProduction = process.env.NODE_ENV === 'production';
+    const isProduction = process.env.NODE_ENV === 'production' && process.env.PRODUCTION === true;
     const initialProps = await Document.getInitialProps(ctx);
 
     return {


### PR DESCRIPTION
Adding an extra check, so that Google Analytics are only recorded in Production.
Without this extra check, Preview environments were also being picked up.

Requires: PRODUCTION env variable setup in Production environments.